### PR TITLE
Fix formula for % below 2xFPL in COC_schema.csv

### DIFF
--- a/Project-Documentation/Equity-Priority-Communities/Data/COC_Schema.csv
+++ b/Project-Documentation/Equity-Priority-Communities/Data/COC_Schema.csv
@@ -22,7 +22,7 @@ pct_over75,DOUBLE,(B01001_023E + B01001_024E + B01001_025E + B01001_047E + B0100
 pct_minority,DOUBLE,(B03002_001E - B03002_003E)/B03002_001E,Minority population as a share of total population,
 pct_spfam,DOUBLE,(B11004_010E + B11004_016E)/B11004_001E,Single-parent family as a share all families,
 pct_lep,DOUBLE,(B16005_007E + B16005_008E + B16005_012E + B16005_013E + B16005_017E + B16005_018E + B16005_022E + B16005_023E + B16005_029E + B16005_030E + B16005_034E + B16005_035E + B16005_039E + B16005_040E + B16005_044E + B16005_045E)/B16005_001E,Limited English proficiency population as a share of total population 5 years and over,
-pct_below200,DOUBLE,C17002_001E - C17002_008E/C17002_001E,Low Income population as a share of total population for whom poverty status is determined,
+pct_below200,DOUBLE,(C17002_001E - C17002_008E)/C17002_001E,Low Income population as a share of total population for whom poverty status is determined,
 pct_disab,DOUBLE,(C18108_001E - (C18108_005E + C18108_009E + C18108_013E))/C18108_001E,Disabled population as a share of total civilian noninstitutionalized population,
 pct_zvhhs,DOUBLE,B08201_002E/B08201_001E,Zero-vehicle households as a share of total households,
 pct_hus_rent50,DOUBLE,B25070_010E/B08201_001E,Severely rent-burdened household as a share of total renter-occupied housing units,


### PR DESCRIPTION
Hi, I was just trying to reproduce some of these, and noticed that the formula for `pct_below200` was incorrect unless parentheses were added. Cheers!